### PR TITLE
can't specify port in the test config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,6 @@ cut and pasteable.  A usable test version is in the repo under example_config.js
   // you'll need one of these
   "wptApiKey": "get one from http://www.webpagetest.org/getkey.php",
 
-  // what port should your server run on.
-  "port": 3001,
-
   // A Suite is a collection of urls under a theme.
   // e.g.: User Profiles.
   "testSuites":[

--- a/example_config.json
+++ b/example_config.json
@@ -1,7 +1,6 @@
 {
 
   "wptApiKey": "get one from http://www.webpagetest.org/getkey.php",
-  "port": 3001,
   "testSuites":[
     {
       "suiteDisplayName": "GoogleVsBingVsDDG",


### PR DESCRIPTION
It was an old feature and the docs were never cleaned up.