### PR TITLE
WPT started to return a _lot_ of data, which was killing performance

### DIFF
--- a/routes/run_tests.js
+++ b/routes/run_tests.js
@@ -192,6 +192,18 @@ function runTest(test) {
       return console.error([err, {url: test.url, options: options}]);
     }
 
+
+    //trim results data, the dataset is huge.
+    try {
+      delete results.data.average;
+      delete results.data.median;
+      delete results.data.standardDeviation;
+      delete results.data.runs[1].firstView.requests;
+      delete results.data.runs[1].repeatView.requests;
+    } catch(e) {
+      debug('ran into trouble deleting extra data.')
+    }
+
     dataStore.saveDatapoint(test, results);
   });
 }


### PR DESCRIPTION
for the naively designed filesystem based dataStore, the 2MB json files were making the server take a bit of forever. This helps.