### PR TITLE
Don't pull in the per request info

### DIFF
--- a/data_store/index.js
+++ b/data_store/index.js
@@ -16,8 +16,6 @@ var interface = {
       delete results.data.average;
       delete results.data.median;
       delete results.data.standardDeviation;
-      delete results.data.runs[1].firstView.requests;
-      delete results.data.runs[1].repeatView.requests;
     } catch(e) {
       debug('ran into trouble deleting extra data.');
     }

--- a/routes/run_tests.js
+++ b/routes/run_tests.js
@@ -187,7 +187,8 @@ function runTest(test) {
         timeout       : 600, //wait for 10 minutes
         video         : true, //this enables the filmstrip
         location      : test.location,
-        firstViewOnly : false //do calculate the second/refresh view
+        firstViewOnly : false, //do calculate the second/refresh view
+        requests      : false //do not capture the details of every request
       }
     ;
 


### PR DESCRIPTION
rather than delete it manually, just never request it.  Makes the test run faster, is less data over the wire and don't need to manually save it.  I didn't know this was an option when the new API response came out.